### PR TITLE
Fix regex DeprecationWarning in gdf2.py

### DIFF
--- a/aseg_gdf2/gdf2.py
+++ b/aseg_gdf2/gdf2.py
@@ -130,13 +130,13 @@ class GDF2(object):
 
             if not ";" in line:
                 logger.debug("line {}: No field definitions: {}".format(i, line))
-                m = re.search("RT=(\w*)", line)
+                m = re.search(r"RT=(\w*)", line)
                 if m:
                     rt = m.group(1)
                     logger.info("line {}: added record type RT={}".format(i, rt))
                     self.record_types[m.group(1)] = {"fields": [], "format": None}
             else:
-                m = re.search("RT=(\w*)", line)
+                m = re.search(r"RT=(\w*)", line)
                 if m:
                     rt = m.group(1)
                     if join_null_data_rts:


### PR DESCRIPTION
#### Description:

This pull-request fixes minor DeprecationWarnings seen when running pytest:
```python
aseg_gdf2/gdf2.py:133
  /usr/local/devel/MyWrk/geo-wrk/aseg_gdf2/aseg_gdf2/aseg_gdf2/gdf2.py:133: 
  DeprecationWarning: invalid escape sequence \w
    m = re.search("RT=(\w*)", line)

aseg_gdf2/gdf2.py:139
  /usr/local/devel/MyWrk/geo-wrk/aseg_gdf2/aseg_gdf2/aseg_gdf2/gdf2.py:139: 
  DeprecationWarning: invalid escape sequence \w
    m = re.search("RT=(\w*)", line)
```

#### Test Results:

All 13 tests passed. No warnings.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC