### PR TITLE
Add GDF2 class tests

### DIFF
--- a/aseg_gdf2/gdf2.py
+++ b/aseg_gdf2/gdf2.py
@@ -83,7 +83,8 @@ class GDF2(object):
 
     def __repr__(self):
         r = super().__repr__()
-        nrecords = self.nrecords
+        # _nrecords is a stub to delay nrecords resolution till requested.
+        nrecords = self._nrecords
         if nrecords is None:
             nrecords = "?"
         r = r[:-1] + " nrecords={}".format(nrecords) + r[-1]

--- a/aseg_gdf2/gdf2.py
+++ b/aseg_gdf2/gdf2.py
@@ -83,7 +83,7 @@ class GDF2(object):
 
     def __repr__(self):
         r = super().__repr__()
-        nrecords = self._nrecords
+        nrecords = self.nrecords
         if nrecords is None:
             nrecords = "?"
         r = r[:-1] + " nrecords={}".format(nrecords) + r[-1]

--- a/tests/test_gdf2_class.py
+++ b/tests/test_gdf2_class.py
@@ -22,9 +22,8 @@ def test_repr_1():
     """
     gdf = aseg_gdf2.read(data_src_1)
     res = gdf.__repr__()
-    assert res, "<aseg_gdf2.gdf2.GDF2 object at 0x10cfdead0 nrecords=23040>"
-    assert gdf.__repr__, "<aseg_gdf2.gdf2.GDF2 object at 0x10cfdead0 nrecords=23040>"
-    assert gdf.nrecords, 23040
+    assert res.endswith("nrecords=23040>")
+    assert gdf.nrecords == 23040
 
 
 def test_get_column_definitions_1():

--- a/tests/test_gdf2_class.py
+++ b/tests/test_gdf2_class.py
@@ -1,0 +1,38 @@
+"""
+Tests for the GDF2 class in aseg_gdf2
+"""
+import os
+import sys
+
+from pathlib import Path
+
+import aseg_gdf2
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+repo = Path(__file__).parent.parent
+
+data_src_1 = os.path.join(
+    repo, "tests", "example_datasets", "3bcfc711", "GA1286_Waveforms"
+)
+
+
+def test_repr_1():
+    """
+    GDF2's repr will display the number of records: nrecords
+    """
+    gdf = aseg_gdf2.read(data_src_1)
+    res = gdf.__repr__()
+    assert res, "<aseg_gdf2.gdf2.GDF2 object at 0x10cfdead0 nrecords=23040>"
+    assert gdf.__repr__, "<aseg_gdf2.gdf2.GDF2 object at 0x10cfdead0 nrecords=23040>"
+    assert gdf.nrecords, 23040
+
+
+def test_get_column_definitions_1():
+    """
+    GDF2.get_column_definitions() will return a list of dictionaries
+    """
+    gdf = aseg_gdf2.read(data_src_1)
+    res = gdf.get_column_definitions()
+    assert len(res) == 5
+    for item in res:
+        assert "name" in item

--- a/tests/test_gdf2_class.py
+++ b/tests/test_gdf2_class.py
@@ -21,9 +21,14 @@ def test_repr_1():
     GDF2's repr will display the number of records: nrecords
     """
     gdf = aseg_gdf2.read(data_src_1)
-    res = gdf.__repr__()
-    assert res.endswith("nrecords=23040>")
-    assert gdf.nrecords == 23040
+
+    # Gdf.nrecords is not called yet, so it is set to "?"
+    assert gdf.__repr__().endswith("nrecords=?>")
+    # Call gdf.nrecords
+    nrecords = gdf.nrecords
+    assert nrecords == 23040
+    # After nrecords is called nrecords will be repored in __repr__
+    assert gdf.__repr__().endswith("nrecords=23040>")
 
 
 def test_get_column_definitions_1():


### PR DESCRIPTION
#### Description 

This pull request adds a 2 GDF2 specific tests  to improve test coverage

- Add separate test file for GDF2 specific tests
- Add test for GDF2's repr which will include the number of records
- Add test for GDF2.get_column_definitions()

#### Tests

All tests pass

pytest results before this pull-request:
```
Name                    Stmts   Miss  Cover
-------------------------------------------
aseg_gdf2/__init__.py       2      0   100%
aseg_gdf2/gdf2.py         270     54    80%
-------------------------------------------
TOTAL                     272     54    80%
```

pytest results after this pull-request:

```
Name                    Stmts   Miss  Cover
-------------------------------------------
aseg_gdf2/__init__.py       2      0   100%
aseg_gdf2/gdf2.py         270     38    86%
-------------------------------------------
TOTAL                     272     38    86%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
